### PR TITLE
fix: Standardize OpenAI API key configuration name

### DIFF
--- a/pages/chatgpt_files.py
+++ b/pages/chatgpt_files.py
@@ -9,7 +9,7 @@ import time
 client = OpenAI(
     organization=st.secrets["openai"]["organization"],
     project=st.secrets["openai"]["project"],
-    api_key=st.secrets["openai"]["testing_key"],
+    api_key=st.secrets["openai"]["secret_key"],
 )
 
 default_model = st.secrets["openai"].get("model", "gpt-4o-mini")

--- a/pages/milvus_files.py
+++ b/pages/milvus_files.py
@@ -40,7 +40,7 @@ def get_openai_client():
     return OpenAI(
         organization=st.secrets["openai"]["organization"],
         project=st.secrets["openai"]["project"],
-        api_key=st.secrets["openai"]["testing_key"],
+        api_key=st.secrets["openai"]["secret_key"],
     )
 
 client = get_openai_client()

--- a/pages/workbench.py
+++ b/pages/workbench.py
@@ -7,7 +7,7 @@ common.sidebar()
 
 # This code is for v1 of the openai package: pypi.org/project/openai
 from openai import OpenAI
-OPENAI_API_KEY=st.secrets["openai"]["api_key"]
+OPENAI_API_KEY=st.secrets["openai"]["secret_key"]
 open_ai_client = OpenAI(
     api_key=OPENAI_API_KEY
 )


### PR DESCRIPTION
- Rename testing_key to secret_key across all OpenAI client configurations
- Affects chatgpt_files.py, milvus_files.py, and workbench.py
- Ensures consistent naming convention for production deployment

🤖 Generated with [Claude Code](https://claude.ai/code)